### PR TITLE
Add best practices guide for Docling Markdown exports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This documentation pages explore the webserver configurations, runtime options, 
 - [Configuration](./configuration.md)
 - [Handling models](./models.md)
 - [Usage](./usage.md)
+- [Best practices for Markdown exports](./best-practices-markdown.md)
 - [Deployment](./deployment.md)
 - [MCP](./mcp.md)
 - [Development](./development.md)

--- a/docs/best-practices-markdown.md
+++ b/docs/best-practices-markdown.md
@@ -5,7 +5,7 @@ This guide outlines recommended steps for turning Docling conversions of PDF tex
 ## Clean up and structure the Markdown output
 
 - **Remove noise from the export.** Delete watermark text, repeated headers or footers, and other stray artifacts that Docling may capture during OCR (for example, repeated headings such as `## OceanofPDF.com`).
-- **Correct obvious OCR mistakes.** When the source document is scanned, rerun OCR with the right language settings (e.g. `ocr_lang=["en"]`) or manually fix obvious errors such as garbled cover titles.
+- **Correct obvious OCR mistakes.** When the source document is scanned, rerun OCR with the right language settings (e.g. `ocr_languages=["en"]`) or manually fix obvious errors such as garbled cover titles.
 - **Reflow text into paragraphs.** Merge single-line sentences back into paragraphs separated by blank lines so the Markdown represents coherent blocks of text.
 - **Combine multi-line headings.** Join consecutive headings that belong together (e.g. `## 1` and `## Breathing Again` should become `## 1. Breathing Again`) so every section has a single, descriptive heading.
 - **Normalize the heading hierarchy.** Promote or demote headings until they reflect the true document structure, using `#` for the book title, `##` for chapters, `###` for subsections, and so on.

--- a/docs/best-practices-markdown.md
+++ b/docs/best-practices-markdown.md
@@ -1,0 +1,36 @@
+# Best Practices for Docling Markdown Output
+
+This guide outlines recommended steps for turning Docling conversions of PDF textbooks into clean, well-structured Markdown that is easy for both humans and downstream tooling to consume.
+
+## Clean up and structure the Markdown output
+
+- **Remove noise from the export.** Delete watermark text, repeated headers or footers, and other stray artifacts that Docling may capture during OCR (for example, repeated headings such as `## OceanofPDF.com`).
+- **Correct obvious OCR mistakes.** When the source document is scanned, rerun OCR with the right language settings (e.g. `ocr_lang=["en"]`) or manually fix obvious errors such as garbled cover titles.
+- **Reflow text into paragraphs.** Merge single-line sentences back into paragraphs separated by blank lines so the Markdown represents coherent blocks of text.
+- **Combine multi-line headings.** Join consecutive headings that belong together (e.g. `## 1` and `## Breathing Again` should become `## 1. Breathing Again`) so every section has a single, descriptive heading.
+- **Normalize the heading hierarchy.** Promote or demote headings until they reflect the true document structure, using `#` for the book title, `##` for chapters, `###` for subsections, and so on.
+
+## Leverage Docling configuration options
+
+- **Preserve structured elements.** Enable `preserve_tables=True` (or the equivalent table settings in the API) to keep table layouts, and set `include_images=True` with `image_export_mode="placeholder"|"referenced"` to retain images for later substitution.
+- **Replace image placeholders.** Docling may emit HTML comments such as `<!-- image -->`; swap these for Markdown image syntax like `![Alt text](images/figure-01.png)` once the extracted files are available.
+- **Capture code and formulas.** Turn on enrichment flags such as `do_code_enrichment=True` and `do_formula_enrichment=True` when dealing with source material that contains programming snippets or equations.
+- **Tune PDF parsing.** Experiment with alternate PDF backends such as `pdf_backend="dlparse_v2"` (Heron layout model) and ensure `do_table_structure=True` remains enabled when you need accurate table column detection.
+- **Record metadata.** Where helpful, add YAML front matter with title, author, and other metadata or keep the DocTags/JSON output alongside Markdown for further processing.
+
+## Improve Markdown formatting for readability
+
+- **Use Markdown emphasis and quotes.** Translate italics, bold, and block quotes from the source into `*italic*`, `**bold**`, and `>` syntax to retain context.
+- **Verify lists and enumerations.** Convert bullet and numbered lists into proper Markdown list syntax so they parse cleanly, especially for references, footnotes, or definitions.
+- **Prefer standard Markdown features.** Avoid raw HTML whenever possible so that the document remains portable and easy to parse.
+- **Mind paragraph spacing.** Keep paragraphs separated by blank lines and optionally wrap lines at natural sentence boundaries for human readability without disrupting machine parsing.
+
+## Optimize for downstream parsing and chunking
+
+- **Choose a chunking strategy.** Decide whether to produce a single Markdown file or split by chapters using Docling's `individual_chunks=True` output mode or manual post-processing.
+- **Anchor sections with headings.** Ensure every major section begins with a unique heading (e.g. `## 5. Bouncing Forward`) to make downstream navigation and splitting straightforward.
+- **Keep related content together.** Ensure figures stay with captions, multi-page tables remain contiguous, and lists are not inadvertently broken across sections.
+- **Plan for token limits.** If the Markdown will feed LLM workflows, aim for sections that roughly align with ~2,000 tokens to simplify later chunking.
+- **Test with a Markdown parser.** Run the final document through a Markdown renderer or AST parser to catch structural issues like missing blank lines or malformed lists.
+
+By applying these practices after running Docling, you can produce Markdown that remains faithful to the source textbook while being clean, readable, and ready for downstream knowledge engineering tasks.

--- a/docs/best-practices-markdown.md
+++ b/docs/best-practices-markdown.md
@@ -27,7 +27,7 @@ This guide outlines recommended steps for turning Docling conversions of PDF tex
 
 ## Optimize for downstream parsing and chunking
 
-- **Choose a chunking strategy.** Decide whether to produce a single Markdown file or split by chapters using Docling's `individual_chunks=True` output mode or manual post-processing.
+- **Choose a chunking strategy.** Decide whether to produce a single Markdown file or split by chapters using Docling's chunked output mode (see the latest Docling documentation for the appropriate option) or manual post-processing.
 - **Anchor sections with headings.** Ensure every major section begins with a unique heading (e.g. `## 5. Bouncing Forward`) to make downstream navigation and splitting straightforward.
 - **Keep related content together.** Ensure figures stay with captions, multi-page tables remain contiguous, and lists are not inadvertently broken across sections.
 - **Plan for token limits.** If the Markdown will feed LLM workflows, aim for sections that roughly align with ~2,000 tokens to simplify later chunking.


### PR DESCRIPTION
## Summary
- document recommended cleanup steps for Docling-produced Markdown, including heading normalization, OCR fixes, and paragraph reflow
- capture configuration tips covering tables, images, OCR, and alternative PDF backends
- highlight formatting and chunking guidance to keep Markdown readable and machine friendly

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68da006989b0832696c39a96b49a11d6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a best-practices guide for Docling Markdown output and links it from the docs index.
> 
> - **Docs**:
>   - **New guide**: `docs/best-practices-markdown.md` covering cleanup (OCR fixes, heading normalization, paragraph reflow), configuration tips (tables, images, code/formula enrichment, PDF backends), formatting, and chunking/parsing guidance.
>   - **Index update**: Add link to the new guide in `docs/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 697adced575f52d03ad384cc771f056cd9244a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->